### PR TITLE
Oprava chyby Content-Type v JSON odpovedi

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -157,6 +157,7 @@ if ($output['isPublicHoliday']) {
 
 if (strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) {
     header("Access-Control-Allow-Origin: *");
+    header('Content-Type: application/json');
     echo json_encode($output);
 } else if (strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false) {
     echo '<html><head><meta charset="utf-8"></head><body><dl>';


### PR DESCRIPTION
Pokud poslu požadavek požadující "application/json", vrátí se správně JSON, ale v hlavičce odpovědi je "Content-Type: text/html; charset=UTF-8" a běžná php knihovna vyhodí chybu, že Content-Type nesedí. Přidal jsem do hlavičky odpovědi správný Content-Type.